### PR TITLE
Fix support for non-latin filenames

### DIFF
--- a/libgen/downloaders.py
+++ b/libgen/downloaders.py
@@ -96,11 +96,15 @@ def get(url: str, timeout: int, stream: bool = False):
     """
     return requests.get(url, stream=stream, timeout=timeout)
 
+def filter_filename(filename: str):
+    """Filters a filename non alphabetic and non delimiters charaters."""
+    valid_chars = '-_.() '
+    return ''.join(c for c in filename if c.isalnum() or c in valid_chars)
+
 
 def save_file(filename: str, data: requests.models.Response):
     """Saves a file to the current directory."""
-    valid_chars = '-_.() abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-    filename = ''.join(c for c in filename if c in valid_chars)
+    filename = filter_filename(filename)
     try:
         with open(filename, 'wb') as f:
             for chunk in data.iter_content(chunk_size=1024):

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -1,0 +1,6 @@
+from libgen.downloaders import filter_filename
+
+
+def test_filter_filename():
+    filename = 'Русский язык (1962) - ####автор@.djvu'
+    assert filter_filename(filename) == 'Русский язык (1962) - автор.djvu'


### PR DESCRIPTION
There is a problem with non-latin title and author. For example Cyrillic filename `Название (1964) Фамилия Имя.pdf` with original code become  ` (1964)   .pdf`. Which isn't expected behavior because there is a lot of books in Russian with Russian filenames. 

So this pull request fixes this issue with migrating from filter non-latin characters to filter [non-alphabetic](https://www.tutorialspoint.com/python/string_isalnum.htm) characters (in UTF sence).